### PR TITLE
Add more filters, sorting and collapsible UI for filters

### DIFF
--- a/app/components/au-select.hbs
+++ b/app/components/au-select.hbs
@@ -1,22 +1,17 @@
+{{#let (unique-id) as |uuid| }}
+{{#if @label}}
+  <AuLabel for="selection">{{@label}}</AuLabel>
+{{/if}}
 <select
-  name="amount"
-  id="amount"
+  name={{or @name "selection"}}
+  id="selection{{uuid}}"
   class="c-select"
+  {{on "change" @onChange}}
 >
-  <option
-    value="10"
-    selected="selected"
-  >
-    10
-  </option>
-  <option
-    value="20"
-  >
-    20
-  </option>
-  <option
-    value="50"
-  >
-    50
-  </option>
+  {{#each @options as |opt|}}
+    <option value={{opt.value}} selected={{eq @selection opt.value}}>
+      {{opt.label}}
+    </option>
+  {{/each}}
 </select>
+{{/let}}

--- a/app/components/au-select.hbs
+++ b/app/components/au-select.hbs
@@ -1,17 +1,16 @@
-{{#let (unique-id) as |uuid| }}
-{{#if @label}}
-  <AuLabel for="selection">{{@label}}</AuLabel>
-{{/if}}
-<select
-  name={{or @name "selection"}}
-  id="selection{{uuid}}"
-  class="c-select"
-  {{on "change" @onChange}}
->
-  {{#each @options as |opt|}}
-    <option value={{opt.value}} selected={{eq @selection opt.value}}>
-      {{opt.label}}
-    </option>
-  {{/each}}
-</select>
+{{#let (unique-id) as |uuid|}}
+  {{#if @label}}
+    <AuLabel for="selection{{uuid}}">{{@label}}</AuLabel>
+  {{/if}}
+  <select
+    id="selection{{uuid}}"
+    name={{or @name "selection"}}
+    class="c-select"
+    {{on "change" @onChange}}>
+    {{#each @options as |opt|}}
+      <option value={{opt.value}} selected={{eq @selection opt.value}}>
+        {{opt.label}}
+      </option>
+    {{/each}}
+  </select>
 {{/let}}

--- a/app/components/collapsible-fieldset.hbs
+++ b/app/components/collapsible-fieldset.hbs
@@ -1,0 +1,13 @@
+<AuFieldset as |f| >
+  <f.legend {{on "click" this.toggle}} class="collapsibleTitle">
+    {{@label}}
+    <AuIcon
+      @icon={{if this.isOpen this.iconOpen this.iconClosed}}
+    />
+  </f.legend>
+  {{#if this.isOpen}}
+    <f.content>
+      {{yield}}
+    </f.content>
+  {{/if}}
+</AuFieldset>

--- a/app/components/collapsible-fieldset.js
+++ b/app/components/collapsible-fieldset.js
@@ -1,0 +1,24 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class CollapsibleFieldsetComponent extends Component {
+  @tracked _isOpen = null;
+
+  get isOpen() {
+    return this._isOpen ?? this.args.isOpenInitially;
+  }
+
+  @action
+  toggle() {
+    this._isOpen = !this.isOpen;
+  }
+
+  get iconOpen() {
+    return 'nav-down';
+  }
+
+  get iconClosed() {
+    return 'nav-right';
+  }
+}

--- a/app/components/concept-scheme-filter.hbs
+++ b/app/components/concept-scheme-filter.hbs
@@ -1,13 +1,10 @@
-<AuFieldset as |f|>
-  <f.legend>{{@label}}</f.legend>
-  <f.content>
-    <AuCheckboxGroup
-      @name={{@label}}
-      @selected={{this.selectedIds}}
-      @onChange={{this.updateSelection}} as |Group|>
-      {{#each this.concepts as |concept|}}
-        <Group.Checkbox @value={{concept.id}}>{{concept.label}}</Group.Checkbox>
-      {{/each}}
-    </AuCheckboxGroup>
-  </f.content>
-</AuFieldset>
+<CollapsibleFieldset @label={{@label}} @isOpenInitially={{@isOpenInitially}} >
+  <AuCheckboxGroup
+    @name={{@label}}
+    @selected={{this.selectedIds}}
+    @onChange={{this.updateSelection}} as |Group|>
+    {{#each this.concepts as |concept|}}
+      <Group.Checkbox @value={{concept.id}}>{{concept.label}}</Group.Checkbox>
+    {{/each}}
+  </AuCheckboxGroup>
+</CollapsibleFieldset>

--- a/app/components/sidebar.hbs
+++ b/app/components/sidebar.hbs
@@ -11,7 +11,6 @@
       clickOutsideDeactivates=this.closeSidebar
     )
   }}
-  {{on "click" this.closeSidebar}}
   role="menu"
   tabindex="-1"
 >

--- a/app/config/constants.js
+++ b/app/config/constants.js
@@ -1,5 +1,8 @@
 export default {
   CONCEPT_SCHEMES: {
+    SERVICE_TYPE_FILTER: 'http://mu.semte.ch/vocabularies/ext/conceptscheme/Type',
+    THEME_FILTER: 'http://mu.semte.ch/vocabularies/ext/conceptscheme/Thema',
+    COMPETENT_AUTHORITY_FILTER: 'http://mu.semte.ch/vocabularies/ext/conceptscheme/BevoegdBestuursniveau',
     SERVICE_TYPE: 'https://productencatalogus.data.vlaanderen.be/id/conceptscheme/Type',
     THEME: 'https://productencatalogus.data.vlaanderen.be/id/conceptscheme/Thema'
   },

--- a/app/controllers/dashboard/index.js
+++ b/app/controllers/dashboard/index.js
@@ -6,11 +6,20 @@ import constants from '../../config/constants';
 const { CONCEPT_SCHEMES } = constants;
 
 export default class DashboardIndexController extends Controller {
-  serviceTypeConceptScheme = CONCEPT_SCHEMES.SERVICE_TYPE;
-  themeConceptScheme = CONCEPT_SCHEMES.THEME;
+  serviceTypeConceptScheme = CONCEPT_SCHEMES.SERVICE_TYPE_FILTER;
+  themeConceptScheme = CONCEPT_SCHEMES.THEME_FILTER;
+  authorityConceptScheme = CONCEPT_SCHEMES.COMPETENT_AUTHORITY_FILTER;
   deadlineOptions = [
     { label: 'Deze maand', value: 'month' },
     { label: 'Dit kwartaal', value: 'quarter' },
+    { label: 'Verstreken', value: 'passed' },
+  ];
+
+  sortingOptions = [
+    { label: 'Deadline', value: 'end-date' },
+    { label: 'A-Z (oplopend)', value: ':no-case:name' },
+    { label: 'Z-A (aflopend)', value: '-:no-case:name' },
+    { label: 'Niewste', value: 'date-created' },
   ];
 
   @tracked page = 0;
@@ -19,7 +28,13 @@ export default class DashboardIndexController extends Controller {
   @tracked searchTermBuffer;
   @tracked types = [];
   @tracked themes = [];
+  @tracked authorities = [];
   @tracked deadline = [];
+  @tracked sortBy;
+  // set in Route `setupController`
+  @tracked themeRecords;
+  @tracked typeRecords;
+  @tracked authorityRecords;
 
   @action
   updateSearchTermBuffer(event) {
@@ -53,8 +68,16 @@ export default class DashboardIndexController extends Controller {
   }
 
   @action
+  updateAuthorityLevelFilter(authorities) {
+    this.authorities = authorities.map((record) => record.id);
+    this.setPage(0);
+  }
+
+  @action
   updateDeadlineFilter(values) {
-    this.deadline = values;
+    // only one deadline is possible at a time
+    // last item in array is the most recently clicked
+    this.deadline = values.slice(-1);
     this.setPage(0);
   }
 

--- a/app/controllers/dashboard/index.js
+++ b/app/controllers/dashboard/index.js
@@ -19,7 +19,7 @@ export default class DashboardIndexController extends Controller {
     { label: 'Deadline', value: 'end-date' },
     { label: 'A-Z (oplopend)', value: ':no-case:name' },
     { label: 'Z-A (aflopend)', value: '-:no-case:name' },
-    { label: 'Niewste', value: 'date-created' },
+    { label: 'Nieuwste', value: 'date-created' },
   ];
 
   @tracked page = 0;

--- a/app/templates/dashboard/index.hbs
+++ b/app/templates/dashboard/index.hbs
@@ -18,32 +18,39 @@
         </ul>
         <div class="au-o-box au-o-box--small">
           <ConceptSchemeFilter
-            @label="Type"
             @conceptScheme={{this.serviceTypeConceptScheme}}
             @selected={{this.typeRecords}}
-            @onChange={{this.updateServiceTypeFilter}} />
+            @onChange={{this.updateServiceTypeFilter}}
+            @label="Type"
+            @isOpenInitially={{not (is-empty this.typeRecords)}} />
         </div>
         <div class="au-o-box au-o-box--small">
-          <ConceptSchemeFilter
-            @label="Thematisch"
-            @conceptScheme={{this.themeConceptScheme}}
-            @selected={{this.themeRecords}}
-            @onChange={{this.updateThemeFilter}} />
+            <ConceptSchemeFilter
+              @conceptScheme={{this.themeConceptScheme}}
+              @selected={{this.themeRecords}}
+              @onChange={{this.updateThemeFilter}}
+              @label="Thematisch"
+              @isOpenInitially={{not (is-empty this.themeRecords)}} />
         </div>
         <div class="au-o-box au-o-box--small">
-          <AuFieldset as |f|>
-            <f.legend>Deadline</f.legend>
-            <f.content>
-              <AuCheckboxGroup
-                @name="deadline"
-                @selected={{this.deadline}}
-                @onChange={{this.updateDeadlineFilter}} as |Group|>
-                {{#each this.deadlineOptions as |opt|}}
-                  <Group.Checkbox @value={{opt.value}}>{{opt.label}}</Group.Checkbox>
-                {{/each}}
-              </AuCheckboxGroup>
-            </f.content>
-          </AuFieldset>
+            <ConceptSchemeFilter
+              @conceptScheme={{this.authorityConceptScheme}}
+              @selected={{this.authorityRecords}}
+              @onChange={{this.updateAuthorityLevelFilter}}
+              @label="Aanbieders"
+              @isOpenInitially={{not (is-empty this.authorityRecords)}} />
+        </div>
+        <div class="au-o-box au-o-box--small">
+          <CollapsibleFieldset @label="Deadline" @isOpenInitially={{not (is-empty this.deadline)}} >
+                <AuCheckboxGroup
+                  @name="deadline"
+                  @selected={{this.deadline}}
+                  @onChange={{this.updateDeadlineFilter}} as |Group|>
+                  {{#each this.deadlineOptions as |opt|}}
+                    <Group.Checkbox @value={{opt.value}}>{{opt.label}}</Group.Checkbox>
+                  {{/each}}
+                </AuCheckboxGroup>
+          </CollapsibleFieldset>
         </div>
       </div>
     </Sidebar>
@@ -80,7 +87,11 @@
           {{/if}}
         </Group>
         <Group>
-          {{!-- Add sorting dropdown --}}
+          <AuSelect
+            @label="Gesorteerd op:"
+            @selection={{this.sortBy}}
+            @options={{this.sortingOptions}}
+            @onChange={{this.updateSorting}} />
         </Group>
       </AuToolbar>
       <AuBodyContainer @scroll={{true}}>


### PR DESCRIPTION
- filters on dashboard can now be collapsed
- 4 sorting options
- can filter on deadline "passed"
- "aanbieders" used a concept-scheme (and "bevoegd bestuur" instead of "uitvoerend bestuur").
- filter logic now works correctly
- deadline is now coded as one option that can be chosen (before multiple could be enabled, but only one would be used for filtering).
- allow selecting filters in small window mode (when sidebar becomes hamburger icon).